### PR TITLE
Fix head Option

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ esac
 
 # Fetch latest release tag from GitHub API
 echo "Fetching latest release..."
-LATEST=$(wget -qO- "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+LATEST=$(wget -qO- "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | head -n 1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
 
 if [ -z "$LATEST" ]; then
     echo "ERROR: Could not determine latest release. Check your internet connection."


### PR DESCRIPTION
On Victron GX devices the installation script ran into an error: 
`root@einstein:~# wget -qO- "https://api.github.com/repos/mitchese/shm-et340/releases/latest" | grep '"tag_name"' | head -1
head: invalid option -- '1'
BusyBox v1.36.1 () multi-call binary.

Usage: head [OPTIONS] [FILE]...
`

The '-n 1' option fixes issue #29 
